### PR TITLE
Fix divide by zero on calculating results when disk size is zero

### DIFF
--- a/check_snmp_storage_ucd.pl
+++ b/check_snmp_storage_ucd.pl
@@ -507,7 +507,7 @@ for ($i=0;$i<$num_int;$i++) {
   my $used_size = (($$result{$size_used_high . '.' . $tindex[$i]} * 4294967296) + $$result{$size_used_low . '.' . $tindex[$i]}) / $output_metric_val;
   
   my $bu = ($used_size);
-  my $pu = ($used_size / $total_size) * 100;
+  my $pu = $used_size > 0 && $total_size > 0 ? ($used_size / $total_size) * 100 : 0;
   
   my $to = $total_size;
 


### PR DESCRIPTION
When you got disks that are the size of zero the check will crash due it tries to divide by zero. You can fix it by just creating a filter to exlude any disks that are the size of zero. Im not sure why anybody want to check zero sized disks, but at least the check will not crash.  